### PR TITLE
Added libsqlite3-dev for Linux tips

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -71,7 +71,7 @@ You most likely will need to install the following libraries before compiling:
 
 ```
 sudo apt-get update
-sudo apt-get install libgomp1 libatlas-base-dev liblapack-dev
+sudo apt-get install libgomp1 libatlas-base-dev liblapack-dev libsqlite3-dev
 ```
 
 ## API Reference


### PR DESCRIPTION
When compiling on a clean Ubuntu 22.04 I ran in to a " /usr/bin/ld: cannot find -lsqlite3: No such file or directory" error. Installing libsqlite3-dev fixed it.